### PR TITLE
docs: refresh README configuration and setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__/
 tests/
 !tests/
 !tests/*.py
+.sme
+.agent

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ tests/
 !tests/
 !tests/*.py
 .sme
-.agent

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 # Sando - Know your network
 
-Sando is a lightweight network monitoring and security platform for home labs and small networks.
+**Sando** is a lightweight, customizable, and powerful **network monitoring solution**. Sando helps you inventory the devices on your network, monitor, detect, and respond to suspicious activity in your network with ease.
+
 It helps answer:
 
 - What hosts are on my network?
 - What internet destinations are they connecting to?
 - What DNS lookups are they doing?
-- Which flows, hosts, countries, ports, or services deserve attention?
+- Which flows, hosts, countries, ports, or services are they talking to?
 
 Videos:
 
@@ -19,16 +20,55 @@ Videos:
 
 ---
 
-## What Sando Does
+## 🌟 **Features**
 
-- Builds an inventory of local hosts from NetFlow, DHCP, Pi-hole, reverse DNS, and optional nmap discovery.
-- Collects NetFlow v5 records from firewalls and routers such as pfSense and OPNsense.
-- Tracks local, router, foreign, new outbound, high-bandwidth, high-risk-port, port-scan, Tor, VPN, reputation-list, and geolocation-related flows.
-- Stores flow, host, DNS, alert, reputation, ASN, traffic-stat, and configuration data in SQLite databases under `/database`.
-- Sends optional notifications to Telegram and Discord.
-- Integrates with Pi-hole, AdGuard Home, Home Assistant, Homepage.dev, MaxMind, IP2ASN, Tor node lists, and reputation feeds.
-- Provides optional DHCP server, passive DHCP monitoring, rogue DHCP detection, and sinkhole DNS features.
-- Exposes a Vue dashboard and a local API for exploring hosts, alerts, traffic, and settings.
+### 🔍 **Network Host Inventorying**
+- Integrated DHCP Server **won't respond to unknown hosts**.
+- DHCP Relay support **supports multiple VLANs** from one DHCP Server.
+- Maintains **network host inventory** and **easily classify hosts on your network**.
+
+### 🔍 **Network Flow Monitoring**
+- Detect **new hosts** joining your network.
+- Monitor **local, router, and foreign flows**.
+- Identify **new outbound connections** and **high-bandwidth flows**.
+
+### 🌍 **Geolocation and Reputation**
+- Detect traffic to **banned countries**.
+- Integrate with **reputation lists** to detect malicious IPs.
+- Detect traffic bypassing **local DNS** or **NTP servers**.
+
+### 📊 **Real-Time Alerts**
+- Get instant alerts via **Telegram** for critical events.
+- Log all detections in a centralized database for easy analysis.
+
+### 🛠️ **Customizable Configurations**
+- Fine-tune detection thresholds and approved lists.
+- Enable or disable specific detection mechanisms.
+- Integrate with **Pi-hole** and **AdGuard** for DNS query monitoring.
+
+### 📊 **Integrations**
+- Works with Home Assistant and Homepage.dev dashboard and potentially more
+- Works with Pihole and PfSense, OPNSense
+- Works with various reputation and geolist providers like MaxMind, IPASN, Tor list, etc
+
+### ⚡ **Lightweight and Efficient**
+- Designed to run on minimal hardware.
+- Perfect for Raspberry Pi, home servers, or virtual machines.
+
+---
+
+## 🎯 **Why Choose Sando?**
+
+- **Simple Setup**: Easy to install and configure.
+- **Customizable**: Tailor the system to your specific needs.
+- **Open Source**: Fully transparent and community-driven.
+
+---
+
+## 🚀 **Get Started Today!**
+
+Take control of your home network with **Sando**. Start monitoring, detecting, and protecting your network today!
+
 
 ---
 
@@ -145,8 +185,6 @@ http://YOUR_SANDO_HOST:3030
 ### Published images vs local builds
 
 Use the `mayberry4477/sando:latest` and `mayberry4477/sando-website:latest` images if you want to pull published containers.
-
-If you build locally from the Dockerfiles, tag the images as `sando:latest` and `sando-website:latest`, or update your compose files to match the local tags you choose.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,106 @@
-
 <p align="center">
   <img src="assets/small.png?text=Sando" alt="Sando Logo" />
 </p>
 
-# 🚀 **Sando** - Know your network!
+# Sando - Know your network
 
-- What hosts are on your network?
+Sando is a lightweight network monitoring and security platform for home labs and small networks.
+It helps answer:
+
+- What hosts are on my network?
 - What internet destinations are they connecting to?
 - What DNS lookups are they doing?
+- Which flows, hosts, countries, ports, or services deserve attention?
+
+Videos:
+
+- [30 second intro](https://www.youtube.com/watch?v=6P8XtUhSUis)
+- [What is Sando?](https://www.youtube.com/watch?v=2rwY5qXNQjk)
 
 ---
 
-## 🛡️ **What is Sando? **
+## What Sando Does
 
-**Sando** is a lightweight, customizable, and powerful **network monitoring solution**. Sando helps you inventory the devices on your network, monitor, detect, and respond to suspicious activity in your network with ease.
-
-**30 Second Intro Video** [Youtube](https://www.youtube.com/watch?v=6P8XtUhSUis)
-**What is Sando?** [Youtube](https://www.youtube.com/watch?v=2rwY5qXNQjk)
-
----
-
-## 🌟 **Features**
-
-### 🔍 **Network Host Inventorying**
-- Integrated DHCP Server **won't respond to unknown hosts**.
-- DHCP Relay support **supports multiple VLANs** from one DHCP Server.
-- Maintains **network host inventory** and **easily classify hosts on your network**.
-
-### 🔍 **Network Flow Monitoring**
-- Detect **new hosts** joining your network.
-- Monitor **local, router, and foreign flows**.
-- Identify **new outbound connections** and **high-bandwidth flows**.
-
-### 🌍 **Geolocation and Reputation**
-- Detect traffic to **banned countries**.
-- Integrate with **reputation lists** to detect malicious IPs.
-- Detect traffic bypassing **local DNS** or **NTP servers**.
-
-### 📊 **Real-Time Alerts**
-- Get instant alerts via **Telegram** for critical events.
-- Log all detections in a centralized database for easy analysis.
-
-### 🛠️ **Customizable Configurations**
-- Fine-tune detection thresholds and approved lists.
-- Enable or disable specific detection mechanisms.
-- Integrate with **Pi-hole** and **AdGuard** for DNS query monitoring.
-
-### 📊 **Integrations**
-- Works with Home Assistant and Homepage.dev dashboard and potentially more
-- Works with Pihole and PfSense, OPNSense
-- Works with various reputation and geolist providers like MaxMind, IPASN, Tor list, etc
-
-### ⚡ **Lightweight and Efficient**
-- Designed to run on minimal hardware.
-- Perfect for Raspberry Pi, home servers, or virtual machines.
+- Builds an inventory of local hosts from NetFlow, DHCP, Pi-hole, reverse DNS, and optional nmap discovery.
+- Collects NetFlow v5 records from firewalls and routers such as pfSense and OPNsense.
+- Tracks local, router, foreign, new outbound, high-bandwidth, high-risk-port, port-scan, Tor, VPN, reputation-list, and geolocation-related flows.
+- Stores flow, host, DNS, alert, reputation, ASN, traffic-stat, and configuration data in SQLite databases under `/database`.
+- Sends optional notifications to Telegram and Discord.
+- Integrates with Pi-hole, AdGuard Home, Home Assistant, Homepage.dev, MaxMind, IP2ASN, Tor node lists, and reputation feeds.
+- Provides optional DHCP server, passive DHCP monitoring, rogue DHCP detection, and sinkhole DNS features.
+- Exposes a Vue dashboard and a local API for exploring hosts, alerts, traffic, and settings.
 
 ---
 
-## 🎯 **Why Choose Sando?**
+## Recent Updates
 
-- **Simple Setup**: Easy to install and configure.
-- **Customizable**: Tailor the system to your specific needs.
-- **Open Source**: Fully transparent and community-driven.
+Recent backend and dashboard updates include:
+
+- Discord notifications: Sando can now send alerts through Discord webhooks in addition to Telegram. See [sando#11](https://github.com/mayberryjp/sando/issues/11) and [sando-website#1](https://github.com/mayberryjp/sando-website/issues/1).
+- Safer configuration UI: sensitive settings are obscured by default in the dashboard and can be temporarily revealed with a show/hide control. This covers Telegram, Discord, Pi-hole, AdGuard, and MaxMind secrets. See [sando-website#5](https://github.com/mayberryjp/sando-website/issues/5).
+- Firewall interface metadata: host/network data can store firewall interface names when that information is available. See [sando#32](https://github.com/mayberryjp/sando/issues/32).
+- Performance database maintenance: `dbperformance` records older than 180 days are removed at backend startup. See [sando#31](https://github.com/mayberryjp/sando/issues/31).
+- Troubleshooting note: if the Sando host/container itself is not appearing in traffic or alerts, make sure the server network is included in `LocalNetworks`. See [sando#7](https://github.com/mayberryjp/sando/issues/7).
 
 ---
 
-## 🚀 **Get Started Today!**
+## Architecture
 
-Take control of your home network with **Sando**. Start monitoring, detecting, and protecting your network today!
+Sando is split into two containers:
 
+- `sando`: Python backend. Runs the NetFlow collector, API, detections, integrations, discovery, watchdog, optional DHCP server, optional sinkhole DNS server, and MCP server.
+- `sando-website`: Vue 3/Vite frontend. Serves the dashboard on port `3030` and calls the backend API.
 
-## 📦 **Installation**
+Data flow:
 
-Please see docker compose example files in the docker_config_examples folder. Below is a docker compose file for the collector.
-
+```text
+Firewall/router NetFlow v5 -> UDP/2055 -> sando collector
+                                      -> SQLite databases in /database
+                                      -> API on TCP/8044
+                                      -> dashboard on TCP/3030
 ```
 
+The backend is managed with supervisord and starts multiple processes. Most detections and optional services are controlled by settings and can be enabled or disabled from the dashboard.
+
+---
+
+## Ports
+
+| Service | Port | Required | Notes |
+| --- | --- | --- | --- |
+| Dashboard | TCP/3030 | Yes | Served by `sando-website` |
+| Local API | TCP/8044 | Yes | Served by `sando` |
+| NetFlow v5 collector | UDP/2055 | Yes | Configure your firewall/router to export here |
+| Sinkhole DNS | TCP/UDP 53 | Optional | Only if `SinkHoleDns` is enabled |
+| DHCP server | UDP/67 | Optional | Only if `DhcpServer` is enabled |
+| MCP server | TCP/8030 | Optional/experimental | Local MCP endpoint |
+
+Do not expose these ports directly to the internet.
+
+---
+
+## Security
+
+Sando is currently intended for trusted private networks. Not all production security controls are implemented yet, including user authentication, API keys, TLS between the dashboard and API, and database encryption.
+
+Recommended security posture:
+
+- Run Sando only on a private LAN or management VLAN.
+- Do not expose `3030`, `8044`, `8030`, `2055`, `53`, or `67` to the internet.
+- Use firewall rules to limit dashboard and API access to admin devices.
+- Back up the `/database` volume because it contains Sando's persistent state.
+- Review opt-in cloud/API settings before enabling them.
+- The dashboard masks sensitive configuration values by default, including Telegram, Discord, Pi-hole, AdGuard, and MaxMind secrets.
+
+---
+
+## Installation
+
+See `docker_config_examples/` for backend examples and `sando-website/docker_example_configs/` in the website repository for dashboard examples.
+
+### Backend collector/API container
+
+```yaml
 version: "3"
 services:
   sando:
@@ -86,16 +111,15 @@ services:
     volumes:
       - /docker/sando:/database
     environment:
-      - SITE=FARM  <-- your site name
-      - TZ=Asia/Tokyo <-- your time zone
-
-
-  ```
-
-Below is a docker compose file for the dashboard. Both containers need to be installed.
-
+      - SITE=FARM
+      - TZ=Asia/Tokyo
 ```
 
+`SITE` is the site name shown in Sando. `/database` is the persistent volume for configuration and all SQLite databases.
+
+### Dashboard container
+
+```yaml
 version: "3"
 services:
   sando-website:
@@ -106,238 +130,295 @@ services:
     volumes:
       - /docker/sando-website:/database
     environment:
-      - TZ=Asia/Tokyo  <-- your time zone
-      - SANDO_API_BASE_URL=http://192.168.230.236:8044  <-- location where you installed the collector. 8044 is default port. Change the IP address. This is a URL that is accessible from a desktop, laptop or mobile phone on your network.
-
+      - TZ=Asia/Tokyo
+      - SANDO_API_BASE_URL=http://192.168.1.10:8044
 ```
 
-After installation navigate get to http://YOUR_IP_REPLACE:3030 .
+`SANDO_API_BASE_URL` must be a URL that your browser can reach from your desktop, laptop, or mobile device. Use the IP address or hostname of the machine running the `sando` backend container.
+
+After both containers are running, open:
+
+```text
+http://YOUR_SANDO_HOST:3030
+```
+
+### Published images vs local builds
+
+Use the `mayberry4477/sando:latest` and `mayberry4477/sando-website:latest` images if you want to pull published containers.
+
+If you build locally from the Dockerfiles, tag the images as `sando:latest` and `sando-website:latest`, or update your compose files to match the local tags you choose.
 
 ---
 
-## 🛠️ **Initial Configuration**
+## Initial Configuration
 
-After initial installation, only the collector is running. First, you'll want to configure Netflowv5 on your PfSense Firewall (or another platform where Netflowv5 is supported). Then you'll want to go to Sando Settings and turn on the detection engine, complete your local network information and turn on specific detections. We suggest turning on the New Host Detection to start with to start building some awareness of your local topology.
+After first startup, configure your router/firewall to export NetFlow v5 to the backend container on UDP port `2055`.
 
-If you want to use Sando's DHCP server, then it can work either from DHCP Relay across multiple VLANs or within one network. All subnets must be configured as local networks.
+Then open the Sando dashboard and configure:
+
+- Local networks, for example `192.168.1.0/24`.
+- Router IP addresses, if you want router-flow detection.
+- Processes and detections you want enabled.
+- Notification integrations, if desired.
+- Optional discovery, Pi-hole, AdGuard, DHCP, sinkhole DNS, reputation, ASN, Tor, or MaxMind integrations.
+
+New host detection is enabled by default in the install configuration and is a good first detection to use while building a local inventory. Other detections can be enabled after you have tuned local networks, approved services, and ignore lists.
+
+If you use Sando's DHCP server, it can work with DHCP relay across multiple VLANs or within one network. All relevant subnets must be configured as local networks.
 
 ---
 
-## 🛠️ **Configure Netflowv5 On Your PfSense Firewall**
+## Configure NetFlow v5 on pfSense
 
-Configuring Netflow on PfSense is a simple two step process.
+Configuring NetFlow on pfSense is usually a two-step process.
 
-First, install the softflowd package on PfSense by going to System -> Package Manager -> Available Packages and searching for "softflowd" and installing it.
+First, install the `softflowd` package from:
 
-Second, after softflowd installation go to Services -> softflowd and configure softflowd. We recommend these configuration settings:
+```text
+System -> Package Manager -> Available Packages
+```
 
-* Enable softflowd: Enabled
-* Interface: LAN (enable on all interfaces you want detection or host discovery)
-* Host: <IP address of your collector container named sando>
-* Port: 2055 (the default collector listen port)
-* Sample: 0 (setting this above 0 is only necessary for high volume sites. This will configure the firewall to only look at some packets)
-* Max Flow: 8192
-* Hop Limit: Unset
-* Netflow nersion: 5
-* Bidirectional Flow: Unchecked
-* Flow Tracking Level: Full
-* Flow Timestamp Precision: Seconds
-* Timeout General: 60 (or the speed at which you want in detection latency. Change this only if you know what you're doing)
-* Timeout other settings: set to 60. Set MaxTimeout to 300.
+Search for `softflowd` and install it.
 
-After this, save your settings.
+Second, go to:
 
-## **Security**
+```text
+Services -> softflowd
+```
 
-As this is still an early release of the software, not all security features have been incorporated like API keys, user login authentication, database or website to database connection encryption (TLS). It's assumed that the container is installed on a private network and is only accessed by the admin. Security features will be implemented in future releases. For now, we're focused on core functionality.
+Recommended settings:
 
+- Enable softflowd: enabled
+- Interface: LAN, plus any other interfaces you want to monitor
+- Host: IP address of the machine running the `sando` backend container
+- Port: `2055`
+- Sample: `0`
+- Max Flow: `8192`
+- Hop Limit: unset
+- NetFlow version: `5`
+- Bidirectional Flow: unchecked
+- Flow Tracking Level: full
+- Flow Timestamp Precision: seconds
+- Timeout General: `60`
+- Other timeout settings: `60`
+- MaxTimeout: `300`
 
-## **Getting Help And Troubleshooting**
+Save the settings and confirm Sando starts receiving flows.
 
-## 📸 **Screenshots**
+---
 
-### **Dashboard**
+## Troubleshooting
+
+Useful checks:
+
+- Dashboard: `http://YOUR_SANDO_HOST:3030`
+- API health: `http://YOUR_SANDO_HOST:8044/api/online/consolidated`
+- Explore database health: `http://YOUR_SANDO_HOST:8044/api/online/explore`
+- Confirm your firewall/router exports NetFlow v5 to `UDP/2055`.
+- Confirm `SANDO_API_BASE_URL` points to a URL reachable from your browser.
+- Check backend and dashboard container logs.
+- Check for port conflicts before enabling sinkhole DNS on port `53` or DHCP on port `67`.
+- If the Sando host/container itself is not showing traffic, confirm the server network is included in `LocalNetworks`.
+
+Common symptoms:
+
+- Dashboard loads but no data appears: check `SANDO_API_BASE_URL`, API health, and browser console errors.
+- API is online but no flows appear: check NetFlow export target IP/port and firewall rules.
+- DNS sinkhole will not start: another DNS service may already be bound to port `53`.
+- DHCP server will not work: another DHCP service may already own port `67`, or relay/local network settings may be incomplete.
+
+Issues and feature requests can be submitted on GitHub.
+
+---
+
+## Configuration Reference
+
+Configuration is stored in the `configuration` SQLite table and can be changed from the dashboard. The defaults below are based on the backend install configuration.
+
+### Detection settings
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `NewHostsDetection` | `1` | Detect new hosts on the network. |
+| `LocalFlowsDetection` | `0` | Detect local network flows. |
+| `RouterFlowsDetection` | `0` | Detect flows involving configured router IPs. |
+| `ForeignFlowsDetection` | `0` | Detect non-local or foreign flows. |
+| `NewOutboundDetection` | `0` | Detect new outbound connections. |
+| `GeolocationFlowsDetection` | `0` | Detect flows involving banned countries. |
+| `BypassLocalDnsDetection` | `0` | Detect clients bypassing approved local DNS servers. |
+| `IncorrectAuthoritativeDnsDetection` | `0` | Detect incorrect authoritative DNS behavior. |
+| `BypassLocalNtpDetection` | `0` | Detect clients bypassing approved local NTP servers. |
+| `IncorrectNtpStratrumDetection` | `0` | Detect incorrect NTP stratum behavior. |
+| `DeadConnectionDetection` | `0` | Detect dead or stale connections. |
+| `ReputationListDetection` | `0` | Detect traffic to reputation-list networks. |
+| `VpnTrafficDetection` | `0` | Detect VPN traffic. |
+| `HighRiskPortDetection` | `0` | Detect traffic involving high-risk ports. |
+| `ManyDestinationsDetection` | `0` | Detect sources talking to many destinations. |
+| `PortScanDetection` | `0` | Detect port scanning behavior. |
+| `TorFlowDetection` | `0` | Detect traffic to known Tor nodes. |
+| `HighBandwidthFlowDetection` | `0` | Detect high-packet or high-byte flows. |
+| `RogueDhcpDetection` | `0` | Detect DHCP servers not in the approved list. |
+| `AlertOnCustomTags` | `0` | Alert on flows matching configured custom tags. |
+
+Note: the current backend configuration key is spelled `IncorrectNtpStratrumDetection`.
+
+### Network and flow settings
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `LocalNetworks` | `[]` | Local network CIDRs. |
+| `StartCollector` | `1` | Start the NetFlow collector. |
+| `ScheduleProcessor` | `1` | Enable scheduled flow processing. |
+| `ProcessRunInterval` | `60` | Detection processor interval in seconds. |
+| `CollectorProcessingInterval` | `60` | Collector processing interval in seconds. |
+| `ProcessingInterval` | `60` | General processing interval. |
+| `CleanNewFlows` | `1` | Clean transient new-flow records after processing. |
+| `RemoveBroadcastFlows` | `1` | Remove broadcast flows from processing. |
+| `RemoveMulticastFlows` | `1` | Remove multicast flows from processing. |
+| `RemoveLinkLocalFlows` | `1` | Remove link-local flows from processing. |
+| `DnsResolverTimeout` | `3` | DNS resolver timeout. |
+| `DnsResolverRetries` | `1` | DNS resolver retry count. |
+| `MaxUniqueDestinations` | `30` | Threshold for many-destination detection. |
+| `MaxPortsPerDestination` | `15` | Threshold for port-scan detection. |
+| `HighRiskPorts` | `135,137,138,139,445,25,587,22,23,3389` | Ports treated as high risk. |
+| `BandwidthAnomalyMuliplierThreshold` | `10` | Bandwidth anomaly multiplier threshold. |
+| `MaxPackets` | `30000` | Packet threshold for high-bandwidth detection. |
+| `MaxBytes` | `30000000` | Byte threshold for high-bandwidth detection. |
+| `TrafficStatsPurgeIntervalDays` | `31` | Age in days before traffic stats are purged. |
+
+The backend also removes `dbperformance` records older than 180 days at startup.
+
+### Approved lists and tuning
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `ApprovedLocalNtpServersList` | empty | Approved local NTP servers. |
+| `ApprovedLocalDnsServersList` | empty | Approved local DNS servers. |
+| `ApprovedAuthoritativeDnsServersList` | empty | Approved authoritative DNS servers. |
+| `ApprovedNtpStratumServersList` | empty | Approved NTP stratum servers. |
+| `ApprovedVpnServersList` | empty | Approved VPN servers. |
+| `ApprovedHighRiskDestinations` | empty | Destinations allowed for high-risk-port flows. |
+| `ApprovedDhcpServersList` | empty | Approved DHCP servers for rogue DHCP detection. |
+| `IgnoreListEntries` | `[]` | Ignore-list entries. |
+| `TagEntries` | `[]` | Custom tag entries. |
+| `AlertOnCustomTagList` | empty | Custom tags that should generate alerts. |
+
+### Geolocation, reputation, ASN, and Tor
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `BannedCountryList` | `North Korea,Iran,Russia,Ukraine,Georgia,Armenia,Azerbaijan,Belarus,Syria,Venezuela,Cuba,Myanmar,Afghanistan` | Countries used by geolocation flow detection. |
+| `MaxMindAPIKey` | empty | MaxMind API key, if used for geolocation data. |
+| `ReputationUrl` | `https://iplists.firehol.org/files/firehol_level1.netset` | Reputation list URL. |
+| `ReputationListRemove` | `192.168.0.0/16,0.0.0.0/8,224.0.0.0/3,169.254.0.0/16` | Networks removed from imported reputation lists. |
+| `TorNodesUrl` | `https://www.dan.me.uk/torlist/?full` | Tor node list URL. |
+| `ImportAsnDatabase` | `1` | Import IP-to-ASN data. |
+| `ImportServicesList` | `1` | Import network service/port metadata. |
+| `IntegrationFetchInterval` | `86400` | Integration fetch interval in seconds. |
+
+### Discovery and DNS history
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `DiscoveryReverseDns` | `0` | Enable reverse DNS discovery. |
+| `DiscoveryPiholeDhcp` | `0` | Import DHCP leases from Pi-hole. |
+| `EnableLocalDiscoveryProcess` | `0` | Enable local discovery process. |
+| `DiscoveryProcessRunInterval` | `28800` | Discovery run interval in seconds. |
+| `DiscoveryNmapOsFingerprint` | `0` | Enable nmap OS fingerprinting. |
+| `StorePiHoleDnsQueryHistory` | `0` | Store Pi-hole DNS query history. |
+| `PiholeUrl` | empty | Pi-hole API URL. |
+| `PiholeApiKey` | empty | Pi-hole API key. |
+| `PiHoleDnsFetchRecordSize` | `10000` | Number of Pi-hole DNS records to fetch. |
+| `PiHoleDnsFetchInterval` | `3600` | Pi-hole DNS fetch interval in seconds. |
+| `StoreAdGuardDnsQueryHistory` | `0` | Store AdGuard Home DNS query history. |
+| `AdGuardUrl` | empty | AdGuard Home URL. |
+| `AdGuardUsername` | empty | AdGuard Home username. |
+| `AdGuardPassword` | empty | AdGuard Home password. |
+| `DnsResponseLookupResolver` | empty | Resolver used to fill missing DNS response data. |
+| `PerformDnsResponseLookupsForInvestigations` | `0` | Enable DNS response lookups for investigations. |
+
+Some AdGuard keys may be created by the UI or integrations rather than seeded in the initial install configuration.
+
+### Notifications
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `TelegramEnabled` | `0` | Enable Telegram notifications. |
+| `TelegramBotToken` | empty | Telegram bot token. |
+| `TelegramChatId` | empty | Telegram chat ID. |
+| `DiscordEnabled` | `0` | Enable Discord webhook notifications. |
+| `DiscordWebhookUrl` | empty | Discord webhook URL. |
+
+Sensitive notification values are obscured by default in the dashboard configuration UI.
+
+### Optional services
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `SinkHoleDns` | `0` | Enable sinkhole DNS server on port `53`. |
+| `DhcpServer` | `0` | Enable Sando DHCP server on port `67`. |
+| `DhcpPassiveMonitoring` | `0` | Enable passive DHCP monitoring. |
+
+The sinkhole DNS server responds with `NXDOMAIN` and records queries. This can help profile or block selected IoT behavior, but it conflicts with other DNS services on port `53`.
+
+### Cloud/API opt-in settings
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `SendConfigurationToCloudApi` | `0` | Send instance configuration to the Sando cloud API. |
+| `SendErrorsToCloudApi` | `0` | Send error reports to the Sando cloud API. |
+| `SendDeviceClassificationsToHomelabApi` | `0` | Upload device classifications. |
+
+These settings are disabled by default. Review what each option sends before enabling it.
+
+### System metadata
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `DatabaseSchemaVersion` | current backend schema version | Stored database schema version. |
+
+---
+
+## Screenshots
+
+### Dashboard
+
 ![Landing page](assets/{BCC535B4-5F5E-4023-B5D7-CE7DE7AEE540}.png)
 
-### **Host View**
+### Host View
+
 ![Host View](assets/{C547E506-22B3-4DB3-87A6-C175C23C660F}.png)
 
-### **Alerts**
+### Alerts
+
 ![Alert Listing](assets/{821572B7-8FAC-4FC2-945C-3818026092DE}.png)
 
-### **Flow Explorer**
+### Flow Explorer
+
 ![Flow Explorer](assets/{E80E5B2B-336D-4098-9203-3E89D35667BB}.png)
 
-### **Settings Page**
+### Settings Page
+
 ![Settings](assets/{77E0E130-E8A7-4BEF-A63A-B711C69BA261}.png)
 
 ---
 
-## 🤝 **Contributing**
+## Contributing
 
-We welcome contributions from the community! Whether it's fixing bugs, adding new features, or improving documentation, your help is appreciated.
-
----
-
-## 📜 **License**
-
-Sando is licensed under the GNU Affero General Public License v3 (AGPLv3). You are free to use, modify, and distribute it under the terms of this license. See the LICENSE file for details.
+Contributions are welcome. Bug fixes, feature work, documentation improvements, and integration examples are all useful.
 
 ---
 
-## 💬 **Join the Community**
+## License
 
-**Reddit**: [r/SandoSecurityAndDhcp](https://www.reddit.com/r/SandoSecurityAndDhcp/)
-**Youtube**: [@SandoSecurityAndDhcp](https://www.youtube.com/@SandoSecurityAndDhcp)
-**GitHub**: [@sando](https://github.com/mayberryjp/sando)
+Sando is licensed under the GNU Affero General Public License v3 (AGPLv3). See `LICENSE` for details.
 
 ---
 
-## ⭐ **Support the Project**
+## Community
 
-If you find Sando useful, please consider giving us a ⭐ on GitHub! It helps others discover the project and motivates us to keep improving.
+- Reddit: [r/SandoSecurityAndDhcp](https://www.reddit.com/r/SandoSecurityAndDhcp/)
+- YouTube: [@SandoSecurityAndDhcp](https://www.youtube.com/@SandoSecurityAndDhcp)
+- GitHub: [mayberryjp/sando](https://github.com/mayberryjp/sando)
 
-**GitHub**: [@sando](https://github.com/mayberryjp/sando)
-
----
-
-# **Sando Configuration Documentation**
-
-## 🛠️ **Configuration Settings**
-
-Sando is highly configurable! Check out the Configuration Documentation for a detailed guide on how to customize the system to your needs.
-
-## **Overview**
-This document provides an overview of the configuration settings used in Sando. These settings control various detection mechanisms, integrations, and system processes. The configurations are stored in the `configuration` table of the database and can be modified to customize the behavior of the system.
-
----
-
-## **Configuration Settings**
-
-### **1. Detection Settings**
-These settings enable or disable specific detection mechanisms.
-
-| **Key**                          | **Description**                                                                                     | **Default Value** |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------|-------------------|
-| `NewHostsDetection`               | Enables detection of new hosts on the network.                                                     | `0`               |
-| `LocalFlowsDetection`             | Enables detection of local network flows.                                                          | `0`               |
-| `RouterFlowsDetection`            | Enables detection of flows originating from or destined to the router.                             | `0`               |
-| `ForeignFlowsDetection`           | Enables detection of foreign (non-local) network flows.                                            | `0`               |
-| `NewOutboundDetection`            | Enables detection of new outbound connections.                                                     | `0`               |
-| `GeolocationFlowsDetection`       | Enables detection of flows based on geolocation data.                                              | `0`               |
-| `BypassLocalDnsDetection`         | Detects flows bypassing local DNS servers.                                                         | `0`               |
-| `IncorrectAuthoritativeDnsDetection` | Detects incorrect authoritative DNS servers.                                                     | `0`               |
-| `BypassLocalNtpDetection`         | Detects flows bypassing local NTP servers.                                                         | `0`               |
-| `IncorrectNtpStratumDetection`   | Detects incorrect NTP stratum levels.                                                              | `0`               |
-
----
-
-### **2. Approved Lists**
-These settings define approved servers or networks for specific purposes.
-
-| **Key**                              | **Description**                                                                 | **Default Value** |
-|--------------------------------------|---------------------------------------------------------------------------------|-------------------|
-| `ApprovedLocalNtpServersList`        | List of approved local NTP servers.                                             | `''`              |
-| `ApprovedLocalDnsServersList`        | List of approved local DNS servers.                                             | `''`              |
-| `ApprovedAuthoritativeDnsServersList`| List of approved authoritative DNS servers.                                     | `''`              |
-| `ApprovedNtpStratumServersList`      | List of approved NTP stratum servers.                                           | `''`              |
-| `ApprovedVpnServersList`             | List of approved VPN servers.                                                   | `''`              |
-| `ApprovedHighRiskDestinations`       | List of approved high-risk destinations.                                        | `''`              |
-
----
-
-### **3. Geolocation and Reputation**
-These settings control geolocation and reputation-based detections.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `BannedCountryList`       | List of countries to ban traffic from.                                          | `China,North Korea,Iran,Russia,Ukraine,...` |
-| `ReputationUrl`           | URL to fetch reputation lists.                                                  | `https://iplists.firehol.org/files/firehol_level1.netset` |
-| `ReputationListRemove`    | List of networks to exclude from reputation lists.                              | `192.168.0.0/16,0.0.0.0/8,224.0.0.0/3`    |
-| `ReputationListDetection` | Enables detection based on reputation lists.                                    | `0`               |
-
----
-
-### **4. Network and Flow Settings**
-These settings control network-related configurations and flow processing.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `LocalNetworks`           | List of local networks.                                                         | `''`              |
-| `RouterIpAddresses`       | List of router IP addresses.                                                    | `''`              |
-| `ProcessingInterval`      | Interval (in seconds) for processing flows.                                     | `60`              |
-| `RemoveBroadcastFlows`    | Removes broadcast flows from processing.                                        | `1`               |
-| `RemoveMulticastFlows`    | Removes multicast flows from processing.                                        | `1`               |
-| `MaxUniqueDestinations`   | Maximum number of unique destinations allowed per source.                       | `30`              |
-| `MaxPortsPerDestination`  | Maximum number of ports allowed per destination.                                | `15`              |
-| `HighRiskPorts`           | List of high-risk ports to monitor.                                             | `135,137,138,139,445,25,587,22,23,3389`   |
-
----
-
-### **5. Telegram Integration**
-These settings configure Telegram bot integration for sending alerts.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `TelegramBotToken`        | Token for the Telegram bot.                                                     | `''`              |
-| `TelegramChatId`          | Chat ID for sending Telegram messages.                                          | `''`              |
-
----
-
-### **6. Pi-hole Integration**
-These settings configure integration with Pi-hole for DNS query monitoring.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `PiholeUrl`               | URL of the Pi-hole API.                                                         | `http://192.168.49.80/api` |
-| `PiholeApiKey`            | API key for accessing the Pi-hole API.                                          | `''`              |
-| `StorePiHoleDnsQueryHistory` | Enables storing Pi-hole DNS query history.                                   | `0`               |
-
----
-
-### **7. Tor Node Detection**
-These settings configure detection of Tor node traffic.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `TorFlowDetection`        | Enables detection of Tor node traffic.                                          | `0`               |
-| `TorNodesUrl`             | URL to fetch the list of Tor nodes.                                             | `https://www.dan.me.uk/torlist/?full` |
-
----
-
-### **8. High Bandwidth Flow Detection**
-These settings configure detection of high-bandwidth flows.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `HighBandwidthFlowDetection` | Enables detection of high-bandwidth flows.                                  | `0`               |
-| `MaxPackets`              | Maximum number of packets allowed per flow.                                     | `30000`           |
-| `MaxBytes`                | Maximum number of bytes allowed per flow.                                       | `3000000`         |
-
----
-
-### **9. Error Reporting**
-These settings control error reporting and logging.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `SendErrorsToCloudApi`    | Enables sending error reports to the cloud API.                                 | `0`               |
-
----
-
-### **10. Miscellaneous Settings**
-These settings control various other aspects of the system.
-
-| **Key**                  | **Description**                                                                 | **Default Value** |
-|---------------------------|---------------------------------------------------------------------------------|-------------------|
-| `ScheduleProcessor`       | Enables scheduling of the processor.                                            | `0`               |
-| `StartCollector`          | Enables starting the collector process.                                         | `1`               |
-| `CleanNewFlows`           | Enables cleaning of new flows.                                                  | `0`               |
-| `IntegrationFetchInterval`| Interval (in seconds) for fetching integrations.                                | `3660`            |
-| `DiscoveryReverseDns`     | Enables reverse DNS discovery.                                                  | `0`               |
-| `DiscoveryPiholeDhcp`     | Enables Pi-hole DHCP discovery.                                                 | `0`               |
-| `EnableLocalDiscoveryProcess` | Enables the local discovery process.                                        | `0`               |
-| `DiscoveryProcessRunInterval` | Interval (in seconds) for running the discovery process.                    | `60`              |
-
----
-
+If Sando is useful, consider starring the project on GitHub.

--- a/src/const.py
+++ b/src/const.py
@@ -1,4 +1,4 @@
-VERSION = "v2026.5.10"
+VERSION = "v2026.6.1"
 # v3 is after consolidating database, v4 is moving to ORM, v5 is moving to constructor, v6 is integrating agent
 CONST_COLLECTOR_LISTEN_PORT = 2055
 CONST_COLLECTOR_LISTEN_ADDRESS = "0.0.0.0"

--- a/tests/test_discord_notifications.py
+++ b/tests/test_discord_notifications.py
@@ -55,7 +55,9 @@ class DiscordNotificationTests(unittest.TestCase):
                 "DiscordWebhookUrl": "https://discord.example/webhook",
                 "DiscordEnabled": "1",
             },
-        ), patch("src.notifications.discord.requests.post", return_value=response), patch(
+        ), patch(
+            "src.notifications.discord.requests.post", return_value=response
+        ), patch(
             "src.notifications.discord.log_error"
         ) as mock_log_error:
             send_discord_message("alert", {})

--- a/tests/test_notifications_core.py
+++ b/tests/test_notifications_core.py
@@ -8,7 +8,9 @@ class CoreNotificationTests(unittest.TestCase):
     def test_handle_alert_sends_discord_for_new_alerts(self):
         with patch(
             "src.notifications.core.get_localhost_by_ip", return_value=None
-        ), patch("src.notifications.core.log_alert_to_db", return_value="insert"), patch(
+        ), patch(
+            "src.notifications.core.log_alert_to_db", return_value="insert"
+        ), patch(
             "src.notifications.core.send_telegram_message"
         ) as mock_telegram, patch(
             "src.notifications.core.send_discord_message"
@@ -32,7 +34,9 @@ class CoreNotificationTests(unittest.TestCase):
     def test_handle_alert_sends_discord_for_level_three_updates(self):
         with patch(
             "src.notifications.core.get_localhost_by_ip", return_value=None
-        ), patch("src.notifications.core.log_alert_to_db", return_value="update"), patch(
+        ), patch(
+            "src.notifications.core.log_alert_to_db", return_value="update"
+        ), patch(
             "src.notifications.core.send_telegram_message"
         ) as mock_telegram, patch(
             "src.notifications.core.send_discord_message"
@@ -56,7 +60,9 @@ class CoreNotificationTests(unittest.TestCase):
     def test_handle_alert_does_not_send_update_notifications_at_level_two(self):
         with patch(
             "src.notifications.core.get_localhost_by_ip", return_value=None
-        ), patch("src.notifications.core.log_alert_to_db", return_value="update"), patch(
+        ), patch(
+            "src.notifications.core.log_alert_to_db", return_value="update"
+        ), patch(
             "src.notifications.core.send_telegram_message"
         ) as mock_telegram, patch(
             "src.notifications.core.send_discord_message"


### PR DESCRIPTION
## Summary
- Restructure the README around architecture, ports, security, installation, and initial setup
- Document missing backend/frontend behavior including Discord notifications, MCP, sinkhole DNS, DHCP/passive DHCP, AdGuard, cloud opt-ins, database storage, and health checks
- Add a Recent Updates section covering recently closed issues in `sando` and `sando-website`, including Discord notifications, sensitive config masking, firewall interface metadata, dbperformance cleanup, and the LocalNetworks troubleshooting note
- Refresh the configuration reference against the backend install defaults and call out the current `IncorrectNtpStratrumDetection` key spelling

## Verification
- Ran `git diff --check`